### PR TITLE
feat(scoring): Add string similarity scoring service

### DIFF
--- a/src/scoring/scoring.service.ts
+++ b/src/scoring/scoring.service.ts
@@ -1,0 +1,43 @@
+import { IEmbeddingProvider } from '../embeddings/interfaces/embedding-provider.interface';
+import { calculateCosineSimilarity } from './utils/cosine-similarity';
+
+/**
+ * Service for calculating similarity scores between strings using embeddings
+ */
+export class ScoringService {
+  /**
+   * Creates a new instance of the ScoringService
+   * @param embeddingProvider - The embedding provider to use for generating embeddings
+   */
+  constructor(private readonly embeddingProvider: IEmbeddingProvider) {}
+
+  /**
+   * Calculates the similarity score between two strings using their embeddings
+   *
+   * @param stringA - First string to compare
+   * @param stringB - Second string to compare
+   * @returns Promise that resolves to a similarity score between -1 and 1
+   * @throws Error if embedding generation fails or vectors are invalid
+   */
+  async scoreStrings(stringA: string, stringB: string): Promise<number> {
+    try {
+      // Generate embeddings for both strings
+      const [embeddingA, embeddingB] = await Promise.all([
+        this.embeddingProvider.generateEmbedding(stringA),
+        this.embeddingProvider.generateEmbedding(stringB),
+      ]);
+
+      // Calculate cosine similarity between the embeddings
+      return calculateCosineSimilarity(
+        embeddingA.embedding,
+        embeddingB.embedding,
+      );
+    } catch (error) {
+      throw new Error(
+        `Failed to calculate similarity score: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
+      );
+    }
+  }
+}

--- a/src/scoring/utils/cosine-similarity.ts
+++ b/src/scoring/utils/cosine-similarity.ts
@@ -1,0 +1,41 @@
+/**
+ * Calculates the cosine similarity between two vectors
+ *
+ * @param vectorA - First vector
+ * @param vectorB - Second vector
+ * @returns Cosine similarity score between -1 and 1
+ * @throws Error if vectors are empty or have different dimensions
+ */
+export function calculateCosineSimilarity(
+  vectorA: number[],
+  vectorB: number[],
+): number {
+  if (vectorA.length === 0 || vectorB.length === 0) {
+    throw new Error('Vectors cannot be empty');
+  }
+
+  if (vectorA.length !== vectorB.length) {
+    throw new Error('Vectors must have the same dimensions');
+  }
+
+  // Calculate dot product
+  let dotProduct = 0;
+  for (let i = 0; i < vectorA.length; i++) {
+    dotProduct += vectorA[i] * vectorB[i];
+  }
+
+  // Calculate magnitudes
+  const magnitudeA = Math.sqrt(
+    vectorA.reduce((sum, val) => sum + val * val, 0),
+  );
+  const magnitudeB = Math.sqrt(
+    vectorB.reduce((sum, val) => sum + val * val, 0),
+  );
+
+  if (magnitudeA === 0 || magnitudeB === 0) {
+    throw new Error('Vectors cannot have zero magnitude');
+  }
+
+  // Calculate cosine similarity
+  return dotProduct / (magnitudeA * magnitudeB);
+}

--- a/src/tests/scoring.test.ts
+++ b/src/tests/scoring.test.ts
@@ -1,0 +1,121 @@
+import { jest } from '@jest/globals';
+import { ScoringService } from '../scoring/scoring.service';
+import { IEmbeddingProvider } from '../embeddings/interfaces/embedding-provider.interface';
+import { EmbeddingResponse } from '../embeddings/types/embedding.types';
+import { calculateCosineSimilarity } from '../scoring/utils/cosine-similarity';
+
+describe('Cosine Similarity', () => {
+  it('should calculate correct cosine similarity for identical vectors', () => {
+    const vector = [1, 2, 3];
+    expect(calculateCosineSimilarity(vector, vector)).toBe(1);
+  });
+
+  it('should calculate correct cosine similarity for orthogonal vectors', () => {
+    const vectorA = [1, 0, 0];
+    const vectorB = [0, 1, 0];
+    expect(calculateCosineSimilarity(vectorA, vectorB)).toBe(0);
+  });
+
+  it('should calculate correct cosine similarity for opposite vectors', () => {
+    const vectorA = [1, 2, 3];
+    const vectorB = [-1, -2, -3];
+    expect(calculateCosineSimilarity(vectorA, vectorB)).toBe(-1);
+  });
+
+  it('should throw error for empty vectors', () => {
+    expect(() => calculateCosineSimilarity([], [1, 2, 3])).toThrow(
+      'Vectors cannot be empty',
+    );
+  });
+
+  it('should throw error for vectors with different dimensions', () => {
+    expect(() => calculateCosineSimilarity([1, 2], [1, 2, 3])).toThrow(
+      'Vectors must have the same dimensions',
+    );
+  });
+
+  it('should throw error for zero magnitude vectors', () => {
+    expect(() => calculateCosineSimilarity([0, 0, 0], [1, 2, 3])).toThrow(
+      'Vectors cannot have zero magnitude',
+    );
+  });
+});
+
+describe('ScoringService', () => {
+  let mockEmbeddingProvider: jest.Mocked<IEmbeddingProvider>;
+  let scoringService: ScoringService;
+
+  beforeEach(() => {
+    mockEmbeddingProvider = {
+      getConfig: jest.fn(),
+      initialize: jest.fn(),
+      generateEmbedding: jest.fn(),
+      validateConfig: jest.fn(),
+      cleanup: jest.fn(),
+    } as jest.Mocked<IEmbeddingProvider>;
+
+    scoringService = new ScoringService(mockEmbeddingProvider);
+  });
+
+  it('should calculate similarity score between two strings', async () => {
+    const mockEmbeddingA: EmbeddingResponse = {
+      embedding: [1, 2, 3],
+      metadata: {
+        model: 'test-model',
+        provider: 'test-provider',
+      },
+    };
+
+    const mockEmbeddingB: EmbeddingResponse = {
+      embedding: [1, 2, 3],
+      metadata: {
+        model: 'test-model',
+        provider: 'test-provider',
+      },
+    };
+
+    mockEmbeddingProvider.generateEmbedding
+      .mockImplementationOnce(() => Promise.resolve(mockEmbeddingA))
+      .mockImplementationOnce(() => Promise.resolve(mockEmbeddingB));
+
+    const score = await scoringService.scoreStrings('hello', 'hello');
+    expect(score).toBe(1); // Identical vectors should have similarity of 1
+    expect(mockEmbeddingProvider.generateEmbedding.mock.calls.length).toBe(2);
+  });
+
+  it('should handle embedding generation errors', async () => {
+    mockEmbeddingProvider.generateEmbedding.mockImplementationOnce(() =>
+      Promise.reject(new Error('Embedding generation failed')),
+    );
+
+    await expect(scoringService.scoreStrings('hello', 'world')).rejects.toThrow(
+      'Failed to calculate similarity score: Embedding generation failed',
+    );
+  });
+
+  it('should handle invalid embedding responses', async () => {
+    const mockEmbeddingA: EmbeddingResponse = {
+      embedding: [1, 2, 3],
+      metadata: {
+        model: 'test-model',
+        provider: 'test-provider',
+      },
+    };
+
+    const mockEmbeddingB: EmbeddingResponse = {
+      embedding: [1, 2], // Different dimension
+      metadata: {
+        model: 'test-model',
+        provider: 'test-provider',
+      },
+    };
+
+    mockEmbeddingProvider.generateEmbedding
+      .mockImplementationOnce(() => Promise.resolve(mockEmbeddingA))
+      .mockImplementationOnce(() => Promise.resolve(mockEmbeddingB));
+
+    await expect(scoringService.scoreStrings('hello', 'world')).rejects.toThrow(
+      'Failed to calculate similarity score: Vectors must have the same dimensions',
+    );
+  });
+});


### PR DESCRIPTION
## Description
Implements a new scoring service that calculates similarity between two strings using embeddings and cosine similarity. This service will be used for evaluating similarity between test case outputs and reference answers.

## Changes
- Added `ScoringService` with `scoreStrings` method to compute similarity between two strings
- Implemented `calculateCosineSimilarity` utility function
- Added comprehensive test suite in `tests/scoring.test.ts`

## Implementation Details
- Uses existing embedding provider infrastructure to generate embeddings
- Calculates cosine similarity between embedding vectors
- Returns a similarity score between -1 and 1
- Handles errors gracefully with meaningful error messages
- Fully documented with JSDoc comments

## Testing
- Unit tests for cosine similarity calculations
- Integration tests with embedding providers
- Error handling test cases
- Edge cases (empty vectors, different dimensions, zero magnitude)

## Related Issue
Closes #17 