### PR TITLE
Update embeddings to use legacy API for embedding calls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ defaultProvider: hebo
 embedding:
   provider: hebo
   model: hebo-embeddings
-  baseUrl: https://api.hebo.ai/v1
+  baseUrl: https://legacy.api.hebo.ai/v1
   apiKey: ${HEBO_API_KEY} # Optional if HEBО_API_KEY is set in environment
 ```
 

--- a/hebo-evals.config.template.yaml
+++ b/hebo-evals.config.template.yaml
@@ -26,5 +26,5 @@ defaultProvider: hebo
 embedding:
   provider: hebo
   model: hebo-embeddings
-  baseUrl: https://api.hebo.ai/v1
+  baseUrl: https://legacy.api.hebo.ai/v1
   apiKey: ${HEBO_EMBEDDING_API_KEY} # Can reuse the same environment variable

--- a/src/embeddings/config/embedding.config.ts
+++ b/src/embeddings/config/embedding.config.ts
@@ -94,7 +94,8 @@ export class EmbeddingProviderFactory {
     return {
       defaultProvider,
       model: process.env.EMBEDDING_MODEL || 'hebo-embeddings',
-      baseUrl: process.env.EMBEDDING_BASE_URL || 'https://api.hebo.ai/v1',
+      baseUrl:
+        process.env.EMBEDDING_BASE_URL || 'https://legacy.api.hebo.ai/v1',
       apiKey: process.env.EMBEDDING_API_KEY || process.env.HEBO_API_KEY || '',
     };
   }

--- a/src/embeddings/implementations/embedding-provider.ts
+++ b/src/embeddings/implementations/embedding-provider.ts
@@ -41,7 +41,7 @@ export class EmbeddingProvider extends BaseEmbeddingProvider {
   private getDefaultBaseUrl(provider: string): string {
     switch (provider) {
       case 'hebo':
-        return 'https://api.hebo.ai/v1';
+        return 'https://legacy.api.hebo.ai/v1';
       case 'openai':
         return 'https://api.openai.com/v1';
       default:

--- a/src/embeddings/types/embedding.types.ts
+++ b/src/embeddings/types/embedding.types.ts
@@ -16,7 +16,7 @@ export interface EmbeddingConfig {
 
   /**
    * Base URL for the embedding API
-   * @default "https://api.openai.com/v1" for OpenAI, "https://api.hebo.ai/v1" for Hebo
+   * @default "https://api.openai.com/v1" for OpenAI, "https://legacy.api.hebo.ai/v1" for Hebo
    */
   baseUrl?: string;
 

--- a/src/tests/embeddings.test.ts
+++ b/src/tests/embeddings.test.ts
@@ -352,7 +352,7 @@ describe('Embedding System', () => {
       );
       expect(result.metadata).toEqual(mockResponse.metadata);
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.hebo.ai/v1/embeddings',
+        'https://legacy.api.hebo.ai/v1/embeddings',
         expect.objectContaining({
           method: 'POST',
           headers: expect.objectContaining({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated examples and notes to use the new default Hebo embeddings endpoint: https://legacy.api.hebo.ai/v1.
- Chores
  - Updated the default base URL for Hebo embeddings in configuration templates and internal defaults to the legacy endpoint.
- Tests
  - Adjusted test expectations to match the new embeddings endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->